### PR TITLE
change lapack -> lapack_root; speedup unit check by unroll hint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ if( BUILD_CLIENTS )
 	# Clients are set up as an external project to take advantage of specifying toolchain files.
 	# We want cmake to go through it's usual discovery process
   ExternalProject_Add( rocblas-clients
-    #DEPENDS rocblas
+    DEPENDS rocblas
     SOURCE_DIR ${PROJECT_SOURCE_DIR}/clients
     BINARY_DIR clients-build
     INSTALL_DIR clients-package

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,13 +52,13 @@ node('rocm-1.3 && fiji')
           // To trim test time, only execute single digit tests
           sh '''
               cd clients-build/tests-build/staging
-              ./rocblas-test-d --gtest_output=xml --gtest_filter=*/?
+              ./rocblas-test --gtest_output=xml --gtest_filter=*/?
           '''
           junit 'clients-build/tests-build/staging/*.xml'
         }
 
         stage("samples") {
-          sh "cd clients-build/samples-build; ./example-sscal-d"
+          sh "cd clients-build/samples-build; ./example-sscal"
         }
       }
     }

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -32,7 +32,7 @@ if( NOT DEFINED GTEST_ROOT )
   list( APPEND rocblas_clients_dependencies googletest )
 endif( )
 
-if( NOT DEFINED LAPACK )
+if( NOT DEFINED LAPACK_ROOT )
   include( external-lapack )
   list( APPEND rocblas_clients_dependencies lapack )
 endif( )

--- a/clients/common/unit.cpp
+++ b/clients/common/unit.cpp
@@ -17,7 +17,9 @@
 
     template<>
     void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, float *hCPU, float *hGPU){
+        #pragma unroll
         for(rocblas_int j=0; j<N; j++){
+            #pragma unroll
             for(rocblas_int i=0;i<M;i++){
 #ifdef GOOGLE_TEST
                 ASSERT_FLOAT_EQ(hCPU[i+j*lda], hGPU[i+j*lda]);
@@ -28,7 +30,9 @@
 
     template<>
     void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, double *hCPU, double *hGPU){
+        #pragma unroll  
         for(rocblas_int j=0; j<N; j++){
+            #pragma unroll
             for(rocblas_int i=0;i<M;i++){
 #ifdef GOOGLE_TEST
                 ASSERT_DOUBLE_EQ(hCPU[i+j*lda], hGPU[i+j*lda]);
@@ -39,7 +43,9 @@
 
     template<>
     void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_float_complex *hCPU, rocblas_float_complex *hGPU){
+        #pragma unroll
         for(rocblas_int j=0; j<N; j++){
+            #pragma unroll
             for(rocblas_int i=0;i<M;i++){
 #ifdef GOOGLE_TEST
                 ASSERT_FLOAT_EQ(hCPU[i+j*lda].x, hGPU[i+j*lda].x);
@@ -51,7 +57,9 @@
 
     template<>
     void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_double_complex *hCPU, rocblas_double_complex *hGPU){
+        #pragma unroll
         for(rocblas_int j=0; j<N; j++){
+            #pragma unroll
             for(rocblas_int i=0;i<M;i++){
 #ifdef GOOGLE_TEST
                 ASSERT_DOUBLE_EQ(hCPU[i+j*lda].x, hGPU[i+j*lda].x);
@@ -63,7 +71,9 @@
 
     template<>
     void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_int *hCPU, rocblas_int *hGPU){
+        #pragma unroll
         for(rocblas_int j=0; j<N; j++){
+            #pragma unroll
             for(rocblas_int i=0;i<M;i++){
 #ifdef GOOGLE_TEST
                 ASSERT_EQ(hCPU[i+j*lda], hGPU[i+j*lda]);


### PR DESCRIPTION

Summary of proposed changes:
-  speedup the google unit check by unrolling the loop 
-  make the naming consistent: XXX_ROOT


