### PR TITLE
set CMake defaults for common use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif( )
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
 if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
-  set( CMAKE_BUILD_TYPE "Debug" CACHE STRINGS "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.")
+  set( CMAKE_BUILD_TYPE "Release" CACHE STRINGS "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.")
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS None Debug Release RelWithDebInfo MinSizeRel)
 endif()
 
@@ -34,9 +34,10 @@ endif( )
 # The superbuild does not build anything itself, all compiling is done in external projects
 project( rocblas-superbuild NONE )
 
-# Everything is initially off, so that cache is not initialized until user elects to build
-option( BUILD_LIBRARY "Build rocBLAS library" OFF )
-option( BUILD_CLIENTS "Build rocBLAS clients" OFF )
+# Default ON settings so cmake builds library and samples
+option( BUILD_LIBRARY "Build rocBLAS library" ON )
+option( BUILD_CLIENTS "Build rocBLAS clients" ON )
+option( BUILD_CLIENTS_SAMPLES "Build rocBLAS client samples" ON )
 
 option( BUILD_WITH_TENSILE "Building rocBLAS with Tensile or not" ON)
 

--- a/README.md
+++ b/README.md
@@ -64,19 +64,19 @@ management.
 7. The return value of all functions is rocblas_status, defined in rocblas_types.h. It is
    used to check for errors.
 
-8. The rocBLAS library is LP64, so rocblas_int arguments are 32 bit and rocblas_long
-   arguments are 64 bit.
-
 
 #### Additional notes
+
+  * The rocBLAS library is LP64, so rocblas_int arguments are 32 bit and rocblas_long
+    arguments are 64 bit.
 
   * rocBLAS uses column-major storage for 2D arrays, and 1 based indexing for
     the functions xMAX and xMIN. This is the same as Legacy BLAS and cuBLAS. 
     If you need row-major and 0 based indexing (used in C language arrays) 
     download the [CBLAS](http://www.netlib.org/blas/#_cblas) file cblas.tgz.
-    Look at the routines that provide a thin interface to Legacy BLAS. They 
-    convert from row-major, 0 based to column-major, 1 based. This is done by 
-    swapping the order of function arguments which is less costly than transposing 
+    Look at the CBLAS functions that provide a thin interface to Legacy BLAS. They 
+    convert from row-major, 0 based, to column-major, 1 based. This is done by 
+    swapping the order of function arguments. It is not necessary to transpose
     matrices.
 
   * The auxiliary functions rocblas_set_pointer and rocblas_get_pointer are used 


### PR DESCRIPTION
The common use is a user building rocBLAS libraries and sample code. The CMakeList.txt options are set so that the common use can be configured with the command  "cmake ..".
