### PR TITLE
cmake install fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,12 +170,18 @@ if( BUILD_LIBRARY )
     set( LIBRARY_CMAKE_ARGS ${LIBRARY_CMAKE_ARGS} -DTensile_ROOT=${Tensile_ROOT})
   endif()
 
+  if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
+    set( LIBRARY_INSTALL_DIR library-package )
+  else( )
+    set( LIBRARY_INSTALL_DIR ${CMAKE_INSTALL_PREFIX} )
+  endif( )
+
   # Build the library as an external project
   ExternalProject_Add( rocblas
     DEPENDS ${rocblas_dependencies}
     SOURCE_DIR ${PROJECT_SOURCE_DIR}/library
     BINARY_DIR library-build
-    INSTALL_DIR library-package
+    INSTALL_DIR ${LIBRARY_INSTALL_DIR}
     LIST_SEPARATOR ^^
     CMAKE_ARGS ${LIBRARY_CMAKE_ARGS}
     ${rocblas_INSTALL_COMMAND}

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -11,7 +11,7 @@ project_version( NAME rocblas-client LANGUAGES CXX )
 #==================================NEW============================
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
-find_package( rocblas REQUIRED CONFIG )
+find_package( rocblas REQUIRED CONFIG PATHS /opt/rocm/rocblas )
 
 # set( Boost_DEBUG ON )
 set( Boost_USE_MULTITHREADED ON )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -78,7 +78,7 @@ endif( )
 
 find_package( GTest REQUIRED )
 find_package( cblas REQUIRED CONFIG  )
-find_package( rocblas REQUIRED CONFIG )
+find_package( rocblas REQUIRED CONFIG PATHS /opt/rocm/rocblas )
 find_package( HIP REQUIRED )
 
 if( BUILD_WITH_TENSILE )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -48,7 +48,7 @@ endif( )
 # This tells cmake to create a compile_commands.json file that can be used with clang tooling or vim
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
-find_package( rocblas REQUIRED CONFIG )
+find_package( rocblas REQUIRED CONFIG PATHS /opt/rocm/rocblas )
 
 set( rocblas_samples_common
       ../common/utility.cpp


### PR DESCRIPTION
Summary of proposed changes:
-  If the user sets the cmake install prefix at configure time, set the install directory of the library to match
-  Hardcode a fallback PATH to the find_package to look into /opt/rocm/rocblas for rocblas CONFIG mode, if it doesn't find rocblas locally in build directory
-  
