### PR TITLE
remove ger redundant template parameters DIM_X DIM_Y

### DIFF
--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -704,6 +704,22 @@ rocblas_dger(rocblas_handle handle,
                  const double *y, rocblas_int incy,
                        double *A, rocblas_int lda);
 
+ROCBLAS_EXPORT rocblas_status
+rocblas_cger(rocblas_handle handle,
+                 rocblas_int m, rocblas_int n,
+                 const rocblas_float_complex *alpha,
+                 const rocblas_float_complex *x, rocblas_int incx,
+                 const rocblas_float_complex *y, rocblas_int incy,
+                       rocblas_float_complex *A, rocblas_int lda);
+
+ROCBLAS_EXPORT rocblas_status
+rocblas_zger(rocblas_handle handle,
+                 rocblas_int m, rocblas_int n,
+                 const rocblas_double_complex *alpha,
+                 const rocblas_double_complex *x, rocblas_int incx,
+                 const rocblas_double_complex *y, rocblas_int incy,
+                       rocblas_double_complex *A, rocblas_int lda);
+
 /*
  * ===========================================================================
  *    level 3 BLAS

--- a/library/src/blas2/ger_device.h
+++ b/library/src/blas2/ger_device.h
@@ -12,7 +12,7 @@
 
 
 
-template<typename T, const rocblas_int DIM_X, const rocblas_int DIM_Y>
+template<typename T>
 static __device__ void
 ger_device(
     rocblas_int m, rocblas_int n,

--- a/library/src/blas2/rocblas_ger.cpp
+++ b/library/src/blas2/rocblas_ger.cpp
@@ -11,7 +11,7 @@
 #include "definitions.h"
 #include "ger_device.h"
 
-template<typename T, const rocblas_int NB_X, const rocblas_int NB_Y>
+template<typename T>
 __global__ void
 ger_kernel_host_pointer(hipLaunchParm lp,
     rocblas_int m, rocblas_int n,
@@ -20,10 +20,10 @@ ger_kernel_host_pointer(hipLaunchParm lp,
     const T * __restrict__ y, rocblas_int incy,
           T *              A, rocblas_int lda)
 {
-    ger_device<T, NB_X, NB_Y>(m, n, alpha, x, incx, y, incy, A, lda);
+    ger_device<T>(m, n, alpha, x, incx, y, incy, A, lda);
 }
 
-template<typename T, const rocblas_int NB_X, const rocblas_int NB_Y>
+template<typename T>
 __global__ void
 ger_kernel_device_pointer(hipLaunchParm lp,
     rocblas_int m, rocblas_int n,
@@ -32,7 +32,7 @@ ger_kernel_device_pointer(hipLaunchParm lp,
     const T * __restrict__ y, rocblas_int incy,
           T *              A, rocblas_int lda)
 {
-    ger_device<T, NB_X, NB_Y>(m, n, *alpha, x, incx, y, incy, A, lda);
+    ger_device<T>(m, n, *alpha, x, incx, y, incy, A, lda);
 }
 
 
@@ -123,12 +123,12 @@ rocblas_ger_template(rocblas_handle handle,
 
     if( rocblas_pointer_to_mode((void*)alpha) == rocblas_pointer_mode_device ) 
     {
-        hipLaunchKernel(HIP_KERNEL_NAME(ger_kernel_device_pointer<T, GEMV_DIM_X, GEMV_DIM_Y>), dim3(ger_grid), dim3(ger_threads), 0, rocblas_stream,
+        hipLaunchKernel(HIP_KERNEL_NAME(ger_kernel_device_pointer<T>), dim3(ger_grid), dim3(ger_threads), 0, rocblas_stream,
                                         m, n, alpha, x, incx, y, incy, A, lda);
     }
     else{
         T h_alpha_scalar = *alpha;
-        hipLaunchKernel(HIP_KERNEL_NAME(ger_kernel_host_pointer<T, GEMV_DIM_X, GEMV_DIM_Y>), dim3(ger_grid), dim3(ger_threads), 0, rocblas_stream,
+        hipLaunchKernel(HIP_KERNEL_NAME(ger_kernel_host_pointer<T>), dim3(ger_grid), dim3(ger_threads), 0, rocblas_stream,
                                         m, n, h_alpha_scalar, x, incx, y, incy, A, lda);
     }
     #undef GEMV_DIM_X


### PR DESCRIPTION

ger functions contained redundant template parameters DIM_X and DIM_Y. These are removed.
