### PR TITLE
use unique_ptr for hipMalloc and malloc

### DIFF
--- a/library/src/blas1/rocblas_amax.cpp
+++ b/library/src/blas1/rocblas_amax.cpp
@@ -204,21 +204,19 @@ rocblas_amax_template(rocblas_handle handle,
 
     rocblas_status status;
 
-    auto workspace_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
-    T2 *workspace = (T2 *) workspace_managed.get();
+    auto workspace = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
     if(!workspace)
     {
         return rocblas_status_memory_error;
     }
 
-    auto workspace_index_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(rocblas_int) * blocks),rocblas::device_free};
-    rocblas_int *workspace_index = (rocblas_int*) workspace_index_managed.get();
+    auto workspace_index = rocblas_unique_ptr{rocblas::device_malloc(sizeof(rocblas_int) * blocks),rocblas::device_free};
     if(!workspace_index)
     {
         return rocblas_status_memory_error;
     }
 
-    status = rocblas_amax_template_workspace<T1, T2>(handle, n, x, incx, result, workspace, workspace_index, blocks);
+    status = rocblas_amax_template_workspace<T1, T2>(handle, n, x, incx, result, (T2*)workspace.get(), (rocblas_int*)workspace_index.get(), blocks);
 
     return status;
 }

--- a/library/src/blas1/rocblas_amax.cpp
+++ b/library/src/blas1/rocblas_amax.cpp
@@ -4,15 +4,13 @@
  * ************************************************************************ */
 #include <hip/hip_runtime.h>
 
-
-
 #include "rocblas.h"
  
 #include "status.h"
 #include "definitions.h"
 #include "device_template.h"
 #include "fetch_template.h"
-
+#include "rocblas_unique_ptr.hpp"
 
 template<typename T1, typename T2, rocblas_int NB>
 __global__ void
@@ -206,20 +204,24 @@ rocblas_amax_template(rocblas_handle handle,
 
     rocblas_status status;
 
-    T2 *workspace;
-    rocblas_int *workspace_index;
+    auto workspace_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
+    T2 *workspace = (T2 *) workspace_managed.get();
+    if(!workspace)
+    {
+        return rocblas_status_memory_error;
+    }
 
-    RETURN_IF_HIP_ERROR(hipMalloc(&workspace, sizeof(T2) * blocks));//potential error may rise here, blocking device operation
-    RETURN_IF_HIP_ERROR(hipMalloc(&workspace_index, sizeof(rocblas_int) * blocks));//potential error may rise here, blocking device operation
+    auto workspace_index_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(rocblas_int) * blocks),rocblas::device_free};
+    rocblas_int *workspace_index = (rocblas_int*) workspace_index_managed.get();
+    if(!workspace_index)
+    {
+        return rocblas_status_memory_error;
+    }
 
     status = rocblas_amax_template_workspace<T1, T2>(handle, n, x, incx, result, workspace, workspace_index, blocks);
 
-    RETURN_IF_HIP_ERROR(hipFree(workspace));
-    RETURN_IF_HIP_ERROR(hipFree(workspace_index));
-
     return status;
 }
-
 
 
 /* ============================================================================================ */

--- a/library/src/blas1/rocblas_amin.cpp
+++ b/library/src/blas1/rocblas_amin.cpp
@@ -204,21 +204,19 @@ rocblas_amin_template(rocblas_handle handle,
 
     rocblas_status status;
 
-    auto workspace_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
-    T2 *workspace = (T2 *) workspace_managed.get();
+    auto workspace = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
     if(!workspace)
     {
         return rocblas_status_memory_error;
     }
 
-    auto workspace_index_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(rocblas_int) * blocks),rocblas::device_free};
-    rocblas_int *workspace_index = (rocblas_int*) workspace_index_managed.get();
+    auto workspace_index = rocblas_unique_ptr{rocblas::device_malloc(sizeof(rocblas_int) * blocks),rocblas::device_free};
     if(!workspace_index)
     {
         return rocblas_status_memory_error;
     }
 
-    status = rocblas_amin_template_workspace<T1, T2>(handle, n, x, incx, result, workspace, workspace_index, blocks);
+    status = rocblas_amin_template_workspace<T1, T2>(handle, n, x, incx, result, (T2*)workspace.get(), (rocblas_int*)workspace_index.get(), blocks);
 
     return status;
 }

--- a/library/src/blas1/rocblas_amin.cpp
+++ b/library/src/blas1/rocblas_amin.cpp
@@ -4,15 +4,13 @@
  * ************************************************************************ */
 #include <hip/hip_runtime.h>
 
- 
-
 #include "rocblas.h"
  
 #include "status.h"
 #include "definitions.h"
 #include "device_template.h"
 #include "fetch_template.h"
-
+#include "rocblas_unique_ptr.hpp"
 
 template<typename T1, typename T2, rocblas_int NB>
 __global__ void
@@ -206,16 +204,21 @@ rocblas_amin_template(rocblas_handle handle,
 
     rocblas_status status;
 
-    T2 *workspace;
-    rocblas_int *workspace_index;
+    auto workspace_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
+    T2 *workspace = (T2 *) workspace_managed.get();
+    if(!workspace)
+    {
+        return rocblas_status_memory_error;
+    }
 
-    RETURN_IF_HIP_ERROR(hipMalloc(&workspace, sizeof(T2) * blocks));//potential error may rise here, blocking device operation
-    RETURN_IF_HIP_ERROR(hipMalloc(&workspace_index, sizeof(rocblas_int) * blocks));//potential error may rise here, blocking device operation
+    auto workspace_index_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(rocblas_int) * blocks),rocblas::device_free};
+    rocblas_int *workspace_index = (rocblas_int*) workspace_index_managed.get();
+    if(!workspace_index)
+    {
+        return rocblas_status_memory_error;
+    }
 
     status = rocblas_amin_template_workspace<T1, T2>(handle, n, x, incx, result, workspace, workspace_index, blocks);
-
-    RETURN_IF_HIP_ERROR(hipFree(workspace));
-    RETURN_IF_HIP_ERROR(hipFree(workspace_index));
 
     return status;
 }

--- a/library/src/blas1/rocblas_asum.cpp
+++ b/library/src/blas1/rocblas_asum.cpp
@@ -190,15 +190,13 @@ rocblas_asum_template(rocblas_handle handle,
 
     rocblas_status status;
 
-    auto workspace_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
-
-    T2 *workspace = (T2 *) workspace_managed.get();
+    auto workspace = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
     if(!workspace)
     {
         return rocblas_status_memory_error;
     }
 
-    status = rocblas_asum_template_workspace<T1, T2>(handle, n, x, incx, result, workspace, blocks);
+    status = rocblas_asum_template_workspace<T1, T2>(handle, n, x, incx, result, (T2*)workspace.get(), blocks);
 
     return status;
 }

--- a/library/src/blas1/rocblas_asum.cpp
+++ b/library/src/blas1/rocblas_asum.cpp
@@ -4,15 +4,13 @@
  * ************************************************************************ */
 #include <hip/hip_runtime.h>
 
- 
-
 #include "rocblas.h"
  
 #include "status.h"
 #include "definitions.h"
 #include "device_template.h"
 #include "fetch_template.h"
-
+#include "rocblas_unique_ptr.hpp"
 
 template<typename T1, typename T2, rocblas_int NB>
 __global__ void
@@ -192,17 +190,18 @@ rocblas_asum_template(rocblas_handle handle,
 
     rocblas_status status;
 
-    T2 *workspace;
-    RETURN_IF_HIP_ERROR(hipMalloc(&workspace, sizeof(T2) * blocks));//potential error may rise here, blocking device operation
+    auto workspace_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
+
+    T2 *workspace = (T2 *) workspace_managed.get();
+    if(!workspace)
+    {
+        return rocblas_status_memory_error;
+    }
 
     status = rocblas_asum_template_workspace<T1, T2>(handle, n, x, incx, result, workspace, blocks);
 
-    RETURN_IF_HIP_ERROR(hipFree(workspace));
-
     return status;
 }
-
-
 
 
 

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -4,13 +4,12 @@
  * ************************************************************************ */
 #include <hip/hip_runtime.h>
 
- 
-
 #include "rocblas.h"
  
 #include "status.h"
 #include "definitions.h"
 #include "device_template.h"
+#include "rocblas_unique_ptr.hpp"
 
 template<typename T, rocblas_int NB>
 __global__ void
@@ -37,9 +36,6 @@ dot_kernel_part1(hipLaunchParm lp,
 
     if(tx == 0) workspace[hipBlockIdx_x] = shared_tep[0];
 }
-
-
-
 
 template<typename T, rocblas_int NB, rocblas_int flag>
 __global__ void
@@ -204,28 +200,25 @@ rocblas_dot_template(rocblas_handle handle,
 
     rocblas_status status;
 
-    T *workspace;
-    RETURN_IF_HIP_ERROR(hipMalloc(&workspace, sizeof(T) * blocks));//potential error may rise here, blocking device operation
+    auto workspace_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T) * blocks),rocblas::device_free};
+
+    T *workspace = (T *) workspace_managed.get();
+    if(!workspace)
+    {
+        return rocblas_status_memory_error;
+    }
 
     status = rocblas_dot_template_workspace<T>(handle, n, x, incx, y, incy, result, workspace, blocks);
-
-    RETURN_IF_HIP_ERROR(hipFree(workspace));
 
     return status;
 }
 
 
-
-
-
-
-/* ============================================================================================ */
-
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
 
 extern "C"

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -200,15 +200,13 @@ rocblas_dot_template(rocblas_handle handle,
 
     rocblas_status status;
 
-    auto workspace_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T) * blocks),rocblas::device_free};
-
-    T *workspace = (T *) workspace_managed.get();
+    auto workspace = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T) * blocks),rocblas::device_free};
     if(!workspace)
     {
         return rocblas_status_memory_error;
     }
 
-    status = rocblas_dot_template_workspace<T>(handle, n, x, incx, y, incy, result, workspace, blocks);
+    status = rocblas_dot_template_workspace<T>(handle, n, x, incx, y, incy, result, (T*)workspace.get(), blocks);
 
     return status;
 }

--- a/library/src/blas1/rocblas_nrm2.cpp
+++ b/library/src/blas1/rocblas_nrm2.cpp
@@ -190,15 +190,13 @@ rocblas_nrm2_template(rocblas_handle handle,
 
     rocblas_status status;
 
-    auto workspace_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
-
-    T2 *workspace = (T2 *) workspace_managed.get();
+    auto workspace = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
     if(!workspace)
     {
         return rocblas_status_memory_error;
     }
 
-    status = rocblas_nrm2_template_workspace<T1, T2>(handle, n, x, incx, result, workspace, blocks);
+    status = rocblas_nrm2_template_workspace<T1, T2>(handle, n, x, incx, result, (T2*)workspace.get(), blocks);
 
     return status;
 }

--- a/library/src/blas3/trtri_trsm.hpp
+++ b/library/src/blas3/trtri_trsm.hpp
@@ -176,8 +176,7 @@ rocblas_trtri_trsm_template(rocblas_handle handle,
 
         T one = 1;  T zero = 0; T negative_one = -1;
 
-        auto C_managed = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T) * IB * IB * blocks),rocblas::device_free};
-        T *C = (T*) C_managed.get();
+        auto C = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T) * IB * IB * blocks),rocblas::device_free};
         if(!C)
         {
             return rocblas_status_memory_error;
@@ -217,7 +216,7 @@ rocblas_trtri_trsm_template(rocblas_handle handle,
                                         (const T*)(A + ((uplo == rocblas_fill_lower) ? IB : IB*lda) ), lda, stride_A,
                                         (const T*)(invA +  ((uplo == rocblas_fill_lower) ? 0 : IB*NB+IB) ) , NB, stride_invA,
                                         &zero,
-                                        C, IB, stride_C,
+                                        (T*)C.get(), IB, stride_C,
                                         blocks );
 
         #ifndef NDEBUG
@@ -229,7 +228,7 @@ rocblas_trtri_trsm_template(rocblas_handle handle,
                                         IB, IB, IB,
                                         &negative_one,
                                         (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB*NB+IB : 0)), NB, stride_invA,
-                                        (const T*)C, IB, stride_C,
+                                        (const T*)C.get(), IB, stride_C,
                                         &zero,
                                         (invA + ((uplo == rocblas_fill_lower) ? IB : IB*NB)), NB, stride_invA,
                                         blocks );


### PR DESCRIPTION
use unique_ptr to avoid memory leak. The changes convert existing code to use unique_ptr
